### PR TITLE
Fix scheduler startup

### DIFF
--- a/mainote_bot/config.py
+++ b/mainote_bot/config.py
@@ -23,7 +23,9 @@ SENTRY_DSN = os.getenv('SENTRY_DSN')
 # Morning Notification Configuration
 MORNING_NOTIFICATION_TIME = os.getenv('MORNING_NOTIFICATION_TIME', '08:00')
 NOTIFICATION_CHAT_IDS = os.getenv('NOTIFICATION_CHAT_IDS', '').split(',')
-ENABLE_MORNING_NOTIFICATIONS = 'true'
+# Morning notifications can be toggled via environment variable
+# Expect values like "true"/"false" (case-insensitive)
+ENABLE_MORNING_NOTIFICATIONS = os.getenv('ENABLE_MORNING_NOTIFICATIONS', 'true').lower() == 'true'
 
 # Note Categories
 NOTE_CATEGORIES = {

--- a/mainote_bot/scheduler/notifications.py
+++ b/mainote_bot/scheduler/notifications.py
@@ -179,9 +179,12 @@ def start_scheduler():
             return
 
         if ENABLE_MORNING_NOTIFICATIONS:
-            logger.info(f"Starting morning notification scheduler (time: {MORNING_NOTIFICATION_TIME}, recipients: {NOTIFICATION_CHAT_IDS})")
-            
+            logger.info(
+                f"Starting morning notification scheduler (time: {MORNING_NOTIFICATION_TIME}, recipients: {NOTIFICATION_CHAT_IDS})"
+            )
+
             # Create the scheduler task
+            asyncio.create_task(schedule_morning_notifications())
             scheduler_running = True
             logger.info("Scheduler task created and started")
         else:


### PR DESCRIPTION
## Summary
- create the scheduler task so notifications actually run
- allow turning morning notifications on/off via env var

## Testing
- `pytest -q`
- `go test ./...` *(fails: "proxy.golang.org ... Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_684c347bcb548328a97f80a4e4c84c82